### PR TITLE
g2llvm: locate src/GhidraToXML.java relative to Ghidra-to-LLVM directory

### DIFF
--- a/g2llvm.py
+++ b/g2llvm.py
@@ -11,9 +11,15 @@ opt_verify = importlib.import_module('src.lifting-opt-verify')
 ghidra_headless_loc = "/home/tej/buildsGhidra/ghidra_9.1.1_PUBLIC/support/analyzeHeadless"
 prj_dir = "/home/tej/GhidraProjects/"
 
+import sys
+import os
+
+# Locate path to Ghidra-to-LLVM directory.
+ghidra2llvm_dir = os.path.realpath(sys.path[0])
+
 # These shouldn't need to be changed
 prj_name = "lifting"
-xml_script = "./src/GhidraToXML.java"
+xml_script = os.path.join(ghidra2llvm_dir, "src/GhidraToXML.java")
 
 # Argument parsing
 parser = argparse.ArgumentParser(description = 'This script lifts a binary from executable to LLVM IR.')


### PR DESCRIPTION
Prior to this commit, invoking g2llvm.py from a directory outside of
Ghidra-to-LLVM would result in a failure to locate src/GhidraToXML.java.

	ERROR REPORT SCRIPT ERROR: ./src/GhidraToXML.java : Script not found: ./src/GhidraToXML.java (HeadlessAnalyzer)

With this commit, the directory of Ghidra-to-LLVM is determined by
taking the realpath of sys.path[0], which either holds the parent
directory of the g2llvm.py script, or an empty string if invoked
from the interpreter. In both cases, realpath will resolve the full
path to the Ghidra-to-LLVM directory, as realpath on an empty string
uses the current working directory to resolve the full path.